### PR TITLE
improve output of errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fb"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs",
  "gumdrop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fb"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -164,7 +164,7 @@ pub fn get_args() -> Result<Args, Box<dyn std::error::Error>> {
         }
         match fs::read_to_string(&jwt_path) {
             Ok(jwt) => args.jwt = String::from(jwt.trim()),
-            Err(error) => eprintln!("Failed to read jwt from {:?}: {:?}", &jwt_path, error),
+            Err(error) => eprintln!("Failed to read jwt from {:?}: {}", &jwt_path, error.to_string()),
         }
     }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -122,7 +122,13 @@ pub async fn authenticate_service_account(context: &mut Context) -> Result<(), B
                 );
             }
         }
-        Err(error) => return Err(format!("Failed to authenticate: {:?}", error).into()),
+        Err(error) => {
+            if context.args.verbose {
+                return Err(format!("Failed to authenticate: {:?}", error).into());
+            }
+
+            return Err(format!("Failed to authenticate: {}", error.to_string()).into());
+        }
     };
 
     return Ok(());

--- a/src/query.rs
+++ b/src/query.rs
@@ -192,7 +192,13 @@ pub async fn query(context: &mut Context, query_text: String) -> Result<(), Box<
                     // on stdout, on purpose
                     println!("{}", resp.text().await?);
                 }
-                Err(error) => eprintln!("Failed to send the request: {:?}", error),
+                Err(error) => {
+                    if context.args.verbose {
+                        eprintln!("Failed to send the request: {:?}", error);
+                    } else {
+                        eprintln!("Failed to send the request: {}", error.to_string());
+                    }
+                },
             };
 
             if !context.args.concise {


### PR DESCRIPTION
```
➤  fb select 42
Failed to send the request: error sending request for url (http://localhost:9123/?&output_format=PSQL): client error (Connect)
Time: 5.1ms
```

instead of 
```
➤  fb select 42
Failed to send the request: reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("localhost")), port: Some(9123), path: "/", query: Some("&output_format=PSQL"), fragment: None }, source: Error { kind: Connect, source: Some(ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })) } }
Time: 4.9ms
```