### PR TITLE
ci(macos): add support for MacOS multi-architecture binaries

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -106,12 +106,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust_arch: x86_64
-            artifact_arch: amd64
-            runs-on: macos-13
           - rust_arch: aarch64
             artifact_arch: arm64
-            runs-on: macos-latest
+            runs-on: macos-26
+          - rust_arch: x86_64
+            artifact_arch: amd64
+            runs-on: macos-26-intel
     name: Build macOS binary for ${{ matrix.artifact_arch }}
     runs-on: ${{ matrix.runs-on }}
 

--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -14,8 +14,12 @@ jobs:
   build-static:
     strategy:
       matrix:
-        arch: [ x86_64, aarch64 ]
-    name: Build Static Binary for ${{ matrix.arch }}
+        include:
+          - rust_arch: x86_64
+            artifact_arch: amd64
+          - rust_arch: aarch64
+            artifact_arch: arm64
+    name: Build Static Binary for ${{ matrix.artifact_arch }}
     runs-on: ubuntu-latest
 
     steps:
@@ -31,7 +35,7 @@ jobs:
         sudo apt-get install -y musl-tools
 
     - name: Download musl-cross toolchain
-      if: matrix.arch == 'aarch64'
+      if: matrix.rust_arch == 'aarch64'
       run: |
         TARGET_ARCH="aarch64-unknown-linux-musl"
         TOOLCHAIN_URL="https://github.com/cross-tools/musl-cross/releases/download/${MUSL_CROSS_VERSION}/${TARGET_ARCH}.tar.xz"
@@ -51,7 +55,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        targets: ${{ matrix.arch }}-unknown-linux-musl
+        targets: ${{ matrix.rust_arch }}-unknown-linux-musl
         
     - name: Cache cargo registry
       uses: actions/cache@v3
@@ -60,17 +64,17 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-${{ matrix.rust_arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.arch }}-cargo-
+          ${{ runner.os }}-${{ matrix.rust_arch }}-cargo-
 
     - name: Build static binary
       run: |
-        cargo build --release --target "${{ matrix.arch }}-unknown-linux-musl" --locked
+        cargo build --release --target "${{ matrix.rust_arch }}-unknown-linux-musl" --locked
 
     - name: Verify static linking with ldd
       run: |
-        BINARY_PATH="target/${{ matrix.arch }}-unknown-linux-musl/release/fb"
+        BINARY_PATH="target/${{ matrix.rust_arch }}-unknown-linux-musl/release/fb"
 
         if ldd "$BINARY_PATH" 2>&1 | grep -qF "not a dynamic executable"; then
           echo "✅ Binary '$BINARY_PATH' is statically linked." >> "$GITHUB_STEP_SUMMARY"
@@ -84,16 +88,70 @@ jobs:
 
     - name: Strip binary
       run: |
-        ${STRIP_PREFIX}strip "target/${{ matrix.arch }}-unknown-linux-musl/release/fb"
+        ${STRIP_PREFIX}strip "target/${{ matrix.rust_arch }}-unknown-linux-musl/release/fb"
 
     - name: Move binary into artifacts directory
       run: |
         mkdir -p artifacts
-        cp "target/${{ matrix.arch }}-unknown-linux-musl/release/fb" "artifacts/fb-linux-static-${{ matrix.arch }}"
+        cp "target/${{ matrix.rust_arch }}-unknown-linux-musl/release/fb" "artifacts/fb-linux-static-${{ matrix.artifact_arch }}"
 
     - name: Upload binary
       uses: actions/upload-artifact@v4
       with:
-        name: fb-linux-static-${{ matrix.arch }}
-        path: artifacts/fb-linux-static-${{ matrix.arch }}
+        name: fb-linux-static-${{ matrix.artifact_arch }}
+        path: artifacts/fb-linux-static-${{ matrix.artifact_arch }}
+        retention-days: 7
+
+  build-macos:
+    strategy:
+      matrix:
+        include:
+          - rust_arch: x86_64
+            artifact_arch: amd64
+            runs-on: macos-13
+          - rust_arch: aarch64
+            artifact_arch: arm64
+            runs-on: macos-latest
+    name: Build macOS binary for ${{ matrix.artifact_arch }}
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        show-progress: 'false'
+        fetch-depth: 0
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+
+    - name: Cache cargo registry
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-${{ matrix.rust_arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.rust_arch }}-cargo-
+
+    - name: Build release binary
+      run: cargo build --release --locked
+
+    - name: Strip binary
+      run: strip target/release/fb
+
+    - name: Move binary into artifacts directory
+      run: |
+        mkdir -p artifacts
+        cp target/release/fb "artifacts/fb-darwin-${{ matrix.artifact_arch }}"
+
+    - name: Upload binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: fb-darwin-${{ matrix.artifact_arch }}
+        path: artifacts/fb-darwin-${{ matrix.artifact_arch }}
         retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,17 +57,29 @@ jobs:
             echo "needs_release=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Download x86_64 binary
+      - name: Download Linux amd64 binary
         if: steps.compare_versions.outputs.needs_release
         uses: actions/download-artifact@v4
         with:
-          name: fb-linux-static-x86_64
+          name: fb-linux-static-amd64
 
-      - name: Download aarch64 binary
+      - name: Download Linux arm64 binary
         if: steps.compare_versions.outputs.needs_release
         uses: actions/download-artifact@v4
         with:
-          name: fb-linux-static-aarch64
+          name: fb-linux-static-arm64
+
+      - name: Download macOS amd64 binary
+        if: steps.compare_versions.outputs.needs_release
+        uses: actions/download-artifact@v4
+        with:
+          name: fb-darwin-amd64
+
+      - name: Download macOS arm64 binary
+        if: steps.compare_versions.outputs.needs_release
+        uses: actions/download-artifact@v4
+        with:
+          name: fb-darwin-arm64
 
       - name: Generate release notes
         if: steps.compare_versions.outputs.needs_release
@@ -86,24 +98,46 @@ jobs:
           release_name: Release v${{ steps.main_branch.outputs.version }}
           body_path: release_notes.md
 
-      - name: Upload x86_64 binary onto release
+      - name: Upload Linux amd64 binary onto release
         if: steps.compare_versions.outputs.needs_release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: fb-linux-static-x86_64
-          asset_name: fb-linux-static-x86_64
+          asset_path: fb-linux-static-amd64
+          asset_name: fb-linux-static-amd64
           asset_content_type: application/octet-stream
 
-      - name: Upload aarch64 binary onto release
+      - name: Upload Linux arm64 binary onto release
         if: steps.compare_versions.outputs.needs_release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: fb-linux-static-aarch64
-          asset_name: fb-linux-static-aarch64
+          asset_path: fb-linux-static-arm64
+          asset_name: fb-linux-static-arm64
+          asset_content_type: application/octet-stream
+
+      - name: Upload macOS amd64 binary onto release
+        if: steps.compare_versions.outputs.needs_release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: fb-darwin-amd64
+          asset_name: fb-darwin-amd64
+          asset_content_type: application/octet-stream
+
+      - name: Upload macOS arm64 binary onto release
+        if: steps.compare_versions.outputs.needs_release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: fb-darwin-arm64
+          asset_name: fb-darwin-arm64
           asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.claude
+.cursor
+.idea
 /target

--- a/README.md
+++ b/README.md
@@ -68,17 +68,58 @@ Optional arguments:
 
 ## Install
 
-1) Install `cargo`: https://doc.rust-lang.org/cargo/getting-started/installation.html 
-    1) Add `source "$HOME/.cargo/env"` to your `~/.bashrc` (or `~/.zshrc`).
-2) Install `pkg-config`: `sudo apt install pkg-config` (a default dependency for Ubuntu)
-3) Install `openssl`: `sudo apt install libssl-dev` (a default dependency for Ubuntu)
-4) Clone & Build & Install:
-```
-git clone git@github.com:firebolt-db/fb-cli.git
-cd fb-cli
-cargo install --path . --locked
-```
-4) That's it: you should be able to run `fb` // or at least `~/.cargo/bin/fb` if cargo env isn't caught up.
+### Precompiled binaries (recommended)
+
+The easiest way to install `fb` is to download a release binary from [**GitHub Releases**](https://github.com/firebolt-db/fb-cli/releases/latest).
+
+1. Open the latest release and download the asset that matches your OS and CPU:
+
+   | Asset | Platform |
+   | ----- | -------- |
+   | `fb-linux-static-amd64` | Linux amd64 (Intel/AMD 64-bit) |
+   | `fb-linux-static-arm64` | Linux arm64 |
+   | `fb-darwin-amd64` | macOS Intel (amd64) |
+   | `fb-darwin-arm64` | macOS Apple Silicon (arm64) |
+
+2. Make it executable and install it as `fb` on your `PATH` (use the exact filename you downloaded):
+
+   ```sh
+   chmod +x ./fb-linux-static-amd64
+   sudo mv ./fb-linux-static-amd64 /usr/local/bin/fb
+   ```
+
+   Or install to your user directory (no `sudo`):
+
+   ```sh
+   mkdir -p ~/.local/bin
+   chmod +x ./fb-linux-static-amd64
+   mv ./fb-linux-static-amd64 ~/.local/bin/fb
+   ```
+
+   Ensure `~/.local/bin` is on your `PATH` (e.g. in `~/.bashrc` or `~/.zshrc`).
+
+3. Run `fb --version` to confirm.
+
+### Build from source (alternative)
+
+Use this if you prefer to compile locally or need a platform not covered by release binaries.
+
+1. Install [Rust and `cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html). Add `source "$HOME/.cargo/env"` to `~/.bashrc` or `~/.zshrc` if the installer suggests it.
+2. On Ubuntu/Debian, install build dependencies:
+
+   ```sh
+   sudo apt install pkg-config libssl-dev
+   ```
+
+3. Clone the repo and install:
+
+   ```sh
+   git clone git@github.com:firebolt-db/fb-cli.git
+   cd fb-cli
+   cargo install --path . --locked
+   ```
+
+4. Run `fb` (or `~/.cargo/bin/fb` if your shell has not picked up Cargo’s bin directory yet).
 
 ## Shortcuts
 


### PR DESCRIPTION
Add macOS binary builds to the CI pipeline and update the README to guide users toward downloading precompiled binaries instead of building from source.