### PR TITLE
Add Windows precompiled binaries to CI releases

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -155,3 +155,52 @@ jobs:
         name: fb-darwin-${{ matrix.artifact_arch }}
         path: artifacts/fb-darwin-${{ matrix.artifact_arch }}
         retention-days: 7
+
+  build-windows:
+    strategy:
+      matrix:
+        include:
+          - rust_target: x86_64-pc-windows-msvc
+            artifact_arch: amd64
+    name: Build Windows binary for ${{ matrix.artifact_arch }}
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        show-progress: 'false'
+        fetch-depth: 0
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        targets: ${{ matrix.rust_target }}
+
+    - name: Cache cargo registry
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~\.cargo\registry
+          ~\.cargo\git
+          target
+        key: ${{ runner.os }}-${{ matrix.rust_target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.rust_target }}-cargo-
+
+    - name: Build release binary
+      run: cargo build --release --target ${{ matrix.rust_target }} --locked
+
+    - name: Move binary into artifacts directory
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Path artifacts -Force | Out-Null
+        Copy-Item "target\${{ matrix.rust_target }}\release\fb.exe" "artifacts\fb-windows-${{ matrix.artifact_arch }}.exe"
+
+    - name: Upload binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: fb-windows-${{ matrix.artifact_arch }}.exe
+        path: artifacts/fb-windows-${{ matrix.artifact_arch }}.exe
+        retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,12 @@ jobs:
         with:
           name: fb-darwin-arm64
 
+      - name: Download Windows amd64 binary
+        if: steps.compare_versions.outputs.needs_release
+        uses: actions/download-artifact@v4
+        with:
+          name: fb-windows-amd64.exe
+
       - name: Generate release notes
         if: steps.compare_versions.outputs.needs_release
         id: release_notes
@@ -140,4 +146,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: fb-darwin-arm64
           asset_name: fb-darwin-arm64
+          asset_content_type: application/octet-stream
+
+      - name: Upload Windows amd64 binary onto release
+        if: steps.compare_versions.outputs.needs_release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: fb-windows-amd64.exe
+          asset_name: fb-windows-amd64.exe
           asset_content_type: application/octet-stream

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,10 +766,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "linux-keyutils",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -2151,6 +2159,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2182,11 +2199,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2202,6 +2236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2252,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2226,10 +2272,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2244,6 +2302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2318,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2268,6 +2338,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2354,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ urlencoding = "2.1"
 pest = "2.7"
 pest_derive = "2.7"
 console = "0.15"
-keyring = { version = "3.6.3", features = ["apple-native", "linux-native"] }
+keyring = { version = "3.6.3", features = ["apple-native", "linux-native", "windows-native"] }
 rand = "0.8"
 sha2 = "0.10"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -80,23 +80,35 @@ The easiest way to install `fb` is to download a release binary from [**GitHub R
    | `fb-linux-static-arm64` | Linux arm64 |
    | `fb-darwin-amd64` | macOS Intel (amd64) |
    | `fb-darwin-arm64` | macOS Apple Silicon (arm64) |
+   | `fb-windows-amd64.exe` | Windows amd64 (Intel/AMD 64-bit) |
 
-2. Make it executable and install it as `fb` on your `PATH` (use the exact filename you downloaded):
+2. Install it on your `PATH`:
 
-   ```sh
-   chmod +x ./fb-linux-static-amd64
-   sudo mv ./fb-linux-static-amd64 /usr/local/bin/fb
-   ```
+   - Linux/macOS: make it executable and install it as `fb` (use the exact filename you downloaded):
 
-   Or install to your user directory (no `sudo`):
+     ```sh
+     chmod +x ./fb-linux-static-amd64
+     sudo mv ./fb-linux-static-amd64 /usr/local/bin/fb
+     ```
 
-   ```sh
-   mkdir -p ~/.local/bin
-   chmod +x ./fb-linux-static-amd64
-   mv ./fb-linux-static-amd64 ~/.local/bin/fb
-   ```
+     Or install to your user directory (no `sudo`):
 
-   Ensure `~/.local/bin` is on your `PATH` (e.g. in `~/.bashrc` or `~/.zshrc`).
+     ```sh
+     mkdir -p ~/.local/bin
+     chmod +x ./fb-linux-static-amd64
+     mv ./fb-linux-static-amd64 ~/.local/bin/fb
+     ```
+
+     Ensure `~/.local/bin` is on your `PATH` (e.g. in `~/.bashrc` or `~/.zshrc`).
+
+   - Windows (PowerShell): place `fb-windows-amd64.exe` somewhere on your `PATH` and optionally rename it to `fb.exe`:
+
+     ```powershell
+     New-Item -ItemType Directory -Force "$env:USERPROFILE\bin" | Out-Null
+     Move-Item .\fb-windows-amd64.exe "$env:USERPROFILE\bin\fb.exe"
+     ```
+
+     Ensure `%USERPROFILE%\bin` is included in your user `Path` environment variable.
 
 3. Run `fb --version` to confirm.
 


### PR DESCRIPTION
## Summary
- add a Windows build job to the shared static-build workflow to produce `fb-windows-amd64.exe`
- include the Windows artifact in the release workflow download/upload steps
- enable `windows-native` feature for the `keyring` crate
- update `Cargo.lock` to keep `--locked` CI builds reproducible with the new dependency feature graph
- update README install docs to include Windows precompiled binary instructions

